### PR TITLE
[fix] `registry` access for CLI tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mv /tmp/conf/000-default.conf /etc/apache2/sites-enabled/000-default.conf &&
 # Place corpora
 COPY data /tmp/data
 RUN mv /tmp/data/corpora/* /home/corpora/ && mv /tmp/data/registry /home/registry && rm -rf /tmp/data && \
- ln -s /home/corpora /corpora
+ ln -s /home /corpora
 
 
 # Compile corpora, fail on error

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mv /tmp/conf/000-default.conf /etc/apache2/sites-enabled/000-default.conf &&
 # Place corpora
 COPY data /tmp/data
 RUN mv /tmp/data/corpora/* /home/corpora/ && mv /tmp/data/registry /home/registry && rm -rf /tmp/data && \
- ln -s /home /corpora
+ ln -s /home/corpora /corpora && ln -s /home/registry /home/corpora/registry
 
 
 # Compile corpora, fail on error

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This docker image is based on Debian stable with some additional hacks for conve
 
 ## Usage
 
-1. Put vert file in: data/corpora/CORPUS_NAME/vertical (see example in data/corpora/susanne/vertical)
-2. Put config in: data/registry/CORPUS_NAME (see example in data/registry/susanne)
-3. (Optional: password authentication) Uncomment relevant config lines in conf/000-default.conf and set user and password in conf/htpasswd   
-4. `docker build . -t nosketch_engine`
+1. Put vert file in: `data/corpora/CORPUS_NAME/vertical` (see example in `data/corpora/susanne/vertical`)
+2. Put config in: `data/registry/CORPUS_NAME` (see example in `data/registry/susanne`)
+3. (Optional: password authentication) Uncomment relevant config lines in `conf/000-default.conf` and set user and password in `conf/htpasswd`   
+4. `docker build . -t nosketch_engine` (can run for 5 minutes or something)
 5. `docker run -p80:80 nosketch_engine`
 6. Navigate to http://DOMAIN/crystal/ to use
 
@@ -36,10 +36,10 @@ docker run -p80:80 eltedh/nosketch-engine
 # License
 
 The following files in this repository are from https://nlp.fi.muni.cz/trac/noske and have their own license:
-- noske_files/manatee-open-*.tar.gz (GPLv2+)
-- noske_files/bonito-open-*.tar.gz (GPLv2+)
-- noske_files/crystal-open-*.tar.gz (GPLv3)
-- noske_files/gdex-*.tar.gz (GPLv3)
-- Susanne sample corpus: data/corpora/susanne/vertical and data/registry/susanne
+- `noske_files/manatee-open-*.tar.gz` (GPLv2+)
+- `noske_files/bonito-open-*.tar.gz` (GPLv2+)
+- `noske_files/crystal-open-*.tar.gz` (GPLv3)
+- `noske_files/gdex-*.tar.gz` (GPLv3)
+- Susanne sample corpus: `data/corpora/susanne/vertical` and `data/registry/susanne`
 
 The rest of the files are licensed under the Lesser GNU GPL version 3 or any later.


### PR DESCRIPTION
CLI tools -- I tested `corpquery` -- search for config files in `/corpora/registry`.

As config files are in `/home/registry` and `/corpora` links to `/home/corpora` we need another link in `Dockerfile`:

```bash
ln -s /home/registry /home/corpora/registry
```
The above may not be the best solution but at least it works.

Tested both in browser and in CLI.

Great piece of software, thanks! :) :heart: