### PR TITLE
cast int to float to avoid "invalid literal for int() with base 10"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,10 @@ RUN cd bonito* && \
     ./setupbonito /var/www/bonito /var/lib/bonito && \
     chown -R www-data:www-data /var/lib/bonito && \
     sed -i 's#wtr = int(words) / float(tokens)#wtr = float(words) / float(tokens)#' \
+        /usr/local/lib/python2.7/dist-packages/bonito/conccgi.py && \
+    sed -i 's#subc_size = sub.search_size()#subc_size = float(sub.search_size())#' \
         /usr/local/lib/python2.7/dist-packages/bonito/conccgi.py
+
 
 ## GDEX
 RUN cd gdex* && \


### PR DESCRIPTION
cast int to float to avoid "invalid literal for int() with base 10" error at large corpora