### PR TITLE
Hack: Link site-pacakges to dist-packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && \
         python3-dev \
         python3-setuptools \
         file \
-        swig
+        swig && \
+    rm -rf /var/lib/apt/lists/*
 
 
 # Enable apache CGI and mod_rewrite
@@ -78,6 +79,8 @@ COPY conf/*.crt /etc/shibboleth/
 # COPY secrets/htpasswd /var/lib/bonito/htpasswd
 # COPY secrets/*.crt /etc/shibboleth/
 
+### HACK4: Set PYTHONPATH ENV variable to help tools to find manatee
+ENV PYTHONPATH=/usr/local/lib/python3.9/site-packages
 
 # Start the container
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "$@"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,13 @@ COPY conf/*.crt /etc/shibboleth/
 # COPY secrets/htpasswd /var/lib/bonito/htpasswd
 # COPY secrets/*.crt /etc/shibboleth/
 
-### HACK4: Set PYTHONPATH ENV variable to help tools to find manatee
-ENV PYTHONPATH=/usr/local/lib/python3.9/site-packages
+### HACK4: Link site-packages to dist-packages to help Python find these packages
+#          (e.g. creating subcorpus and keywords on it -> calls mkstats with popen which calls manatee internally)
+RUN ln -s /usr/local/lib/python3.9/site-packages/ /usr/lib/python3/dist-packages/bonito && \
+    ln -s /usr/local/lib/python3.9/site-packages/manatee.py /usr/lib/python3/dist-packages/manatee.py && \
+    ln -s /usr/local/lib/python3.9/site-packages/_manatee.so /usr/lib/python3/dist-packages/_manatee.so && \
+    ln -s /usr/local/lib/python3.9/site-packages/_manatee.a /usr/lib/python3/dist-packages/_manatee.a && \
+    ln -s /usr/local/lib/python3.9/site-packages/_manatee.la /usr/lib/python3/dist-packages/_manatee.la
 
 # Start the container
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "$@"]

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.9/site-packages
-
 # If no params then start the server,
 # else run the specified command from /usr/local/bin
 if [ $# -eq 1 ]; then


### PR DESCRIPTION
Link site-packages to dist-packages to help Python find these packages
(e.g. creating subcorpus and keywords on it -> calls `mkstats` with popen which calls manatee internally)

This solves two problems:

1. Manatee is installed in `/usr/local/lib/python3.9/site-packages` directly (not e.g. in `/usr/local/lib/python3.9/site-packages/manatee`)
2.  `/usr/local/lib/python3.9/site-packages` is not in the path especially in restricted environments (e.g. `mkstats` called with popen)