### PR TITLE
[mod] "CLI Usage" @ `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ Customise the environment variables in `secrets/env.sh` (see [`secrets/env.sh.te
 
 #### 3b. CLI Usage
 
-- To run NoSketch Engine CLI commands run the docker image and add the desired command and its parameters
- (e.g. `corpinfo -s susanne`) at the end of the command:
-    - `make execute CMD="corpinfo -s susanne"`
-    - or:
-       `docker run --rm -it --mount type=bind,src=$$(pwd)/corpora,dst=/corpora ${IMAGE_NAME}:latest corpinfo -s susanne`
-- To get a shell to a running container use `make connect`
+- `make execute`: runs NoSketch Engine CLI commands using the docker image. Specify the command to run in the `CMD` parameter.
+  For example:
+  - `make execute CMD='corpinfo -s susanne'`\
+    gives info about the _susanne_ corpus
+  - `make execute CMD='corpquery mnsz2_v2.0.5 "[lemma=\"visz\"][word=\"a\"][word=\"prímet\"]"'`\
+    runs the specified query on _mnsz2_v2.0.5_ corpus. Mind the use of quotation marks: `\"` inside `"` inside `'`.
+- `make connect`: gives a shell to a running container
 
 ### 4. Additional commands
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Customise the environment variables in `secrets/env.sh` (see [`secrets/env.sh.te
   For example:
   - `make execute CMD='corpinfo -s susanne'`\
     gives info about the _susanne_ corpus
-  - `make execute CMD='corpquery mnsz2_v2.0.5 "[lemma=\"visz\"][word=\"a\"][word=\"prímet\"]"'`\
-    runs the specified query on _mnsz2_v2.0.5_ corpus. Mind the use of quotation marks: `\"` inside `"` inside `'`.
+  - `make execute CMD='corpquery emagyardemo "[lemma=\"és\"]"'`\
+    runs the specified query on the _emagyardemo_ corpus and gives 2 hits.\
+    Mind the use of quotation marks: `\"` inside `"` inside `'`.
 - `make connect`: gives a shell to a running container
 
 ### 4. Additional commands


### PR DESCRIPTION
clarify and simplify "CLI Usage" and add a useful example for running a query by `corpquery`-- emphasizing usage of quotation mark as described in #10